### PR TITLE
fix: Handle present but zero-length attributes in waveform module

### DIFF
--- a/src/rust/dcmfx_waveform/src/iods/channel_definition.rs
+++ b/src/rust/dcmfx_waveform/src/iods/channel_definition.rs
@@ -13,7 +13,7 @@ use crate::iods::coded_concept::CodedConcept;
 use crate::iods::waveform_module::WaveformSampleInterpretation;
 use crate::iods::{
   get_optional_float, get_optional_stored_value, get_optional_string,
-  insert_stored_value,
+  has_value, insert_stored_value,
 };
 
 /// The definition of a single channel of a waveform multiplex group, read
@@ -122,22 +122,19 @@ impl ChannelDefinition {
     sample_interpretation: WaveformSampleInterpretation,
   ) -> Result<Self, DataError> {
     let waveform_channel_number =
-      if item.has(dictionary::WAVEFORM_CHANNEL_NUMBER.tag) {
+      if has_value(item, dictionary::WAVEFORM_CHANNEL_NUMBER.tag) {
         Some(item.get_int::<i32>(dictionary::WAVEFORM_CHANNEL_NUMBER.tag)?)
       } else {
         None
       };
 
-    let label = if item.has(dictionary::CHANNEL_LABEL.tag) {
-      Some(item.get_string(dictionary::CHANNEL_LABEL.tag)?.to_string())
-    } else {
-      None
-    };
+    let label = get_optional_string(item, dictionary::CHANNEL_LABEL.tag)?;
 
-    let status = if item.has(dictionary::CHANNEL_STATUS.tag) {
+    let status = if has_value(item, dictionary::CHANNEL_STATUS.tag) {
       item
         .get_strings(dictionary::CHANNEL_STATUS.tag)?
         .iter()
+        .filter(|s| !s.is_empty())
         .map(|s| ChannelStatus::from_string(s))
         .collect()
     } else {
@@ -421,6 +418,7 @@ impl ChannelStatus {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use dcmfx_core::ValueRepresentation;
 
   fn test_channel_definition() -> ChannelDefinition {
     ChannelDefinition {

--- a/src/rust/dcmfx_waveform/src/iods/mod.rs
+++ b/src/rust/dcmfx_waveform/src/iods/mod.rs
@@ -39,28 +39,49 @@ pub(crate) fn get_single_sequence_item(
   }
 }
 
+/// Returns whether a data element is present in the data set and has a value
+/// that isn't zero-length. Data elements with a zero-length value are treated
+/// as absent, as this is how they are commonly used to indicate that no value
+/// is available.
+///
+/// Ref: PS3.3 5.4.
+///
+pub(crate) fn has_value(data_set: &DataSet, tag: DataElementTag) -> bool {
+  data_set.has(tag)
+    && data_set
+      .get_value_bytes(tag)
+      .map(|bytes| !bytes.is_empty())
+      .unwrap_or(true)
+}
+
 /// Returns the value of an optional string data element, or `None` when it
-/// isn't present in the data set.
+/// isn't present in the data set or has a zero-length value.
 ///
 pub(crate) fn get_optional_string(
   data_set: &DataSet,
   tag: DataElementTag,
 ) -> Result<Option<String>, DataError> {
-  if data_set.has(tag) {
-    Ok(Some(data_set.get_string(tag)?.to_string()))
-  } else {
-    Ok(None)
+  if !has_value(data_set, tag) {
+    return Ok(None);
+  }
+
+  // A value containing only padding also indicates that no value is available.
+  // Such values are out of spec, as a zero-length value should be used
+  // instead, but they occur in the wild.
+  match data_set.get_string(tag)? {
+    "" => Ok(None),
+    value => Ok(Some(value.to_string())),
   }
 }
 
 /// Returns the value of an optional float data element, or `None` when it
-/// isn't present in the data set.
+/// isn't present in the data set or has a zero-length value.
 ///
 pub(crate) fn get_optional_float(
   data_set: &DataSet,
   tag: DataElementTag,
 ) -> Result<Option<f64>, DataError> {
-  if data_set.has(tag) {
+  if has_value(data_set, tag) {
     Ok(Some(data_set.get_float(tag)?))
   } else {
     Ok(None)
@@ -77,7 +98,7 @@ pub(crate) fn get_optional_stored_value(
   tag: DataElementTag,
   sample_interpretation: WaveformSampleInterpretation,
 ) -> Result<Option<i64>, DataError> {
-  if !item.has(tag) {
+  if !has_value(item, tag) {
     return Ok(None);
   }
 

--- a/src/rust/dcmfx_waveform/src/iods/waveform_module.rs
+++ b/src/rust/dcmfx_waveform/src/iods/waveform_module.rs
@@ -17,7 +17,7 @@ use crate::iods::channel_definition::ChannelDefinition;
 use crate::iods::coded_concept::CodedConcept;
 use crate::iods::{
   get_optional_float, get_optional_stored_value, get_optional_string,
-  insert_stored_value,
+  has_value, insert_stored_value,
 };
 
 /// Holds values of all of the data elements in the Waveform module, which
@@ -238,7 +238,7 @@ impl WaveformMultiplexGroup {
       get_optional_float(item, dictionary::TRIGGER_TIME_OFFSET.tag)?;
 
     let trigger_sample_position =
-      if item.has(dictionary::TRIGGER_SAMPLE_POSITION.tag) {
+      if has_value(item, dictionary::TRIGGER_SAMPLE_POSITION.tag) {
         Some(item.get_int::<u32>(dictionary::TRIGGER_SAMPLE_POSITION.tag)?)
       } else {
         None


### PR DESCRIPTION
The waveform module was not handling the case where a Type 3 attribute (for example) was included in the dataset but with zero length, which is to be interpreted as the attribute being absent. For example:

```
(003A,0222) DS Notch Filter Frequency               [     0 bytes] ""
```

This fix changes the implementation of the get_optional helpers to handle this properly. An ECG DICOM that was previously failing because of the above is correctly handled by the waveform module.