### PR TITLE
feat: Add `--omit-file-header` option to the `modify` command

### DIFF
--- a/src/rust/dcmfx_cli/src/commands/modify_command.rs
+++ b/src/rust/dcmfx_cli/src/commands/modify_command.rs
@@ -89,6 +89,15 @@ pub struct ModifyArgs {
 
   #[arg(
     long,
+    help_heading = "Output",
+    help = "Omit the File Preamble, 'DICM' prefix, and File Meta Information \
+      from the output.",
+    default_value_t = false
+  )]
+  omit_file_header: bool,
+
+  #[arg(
+    long,
     help_heading = "Data Set Content",
     help = "A DICOM JSON data set to merge into the output DICOM P10 data \
       sets. If this specifies data elements already present in the input data \
@@ -312,6 +321,14 @@ pub async fn run(args: ModifyArgs) -> Result<(), ()> {
     return Err(());
   }
 
+  if args.omit_file_header && args.in_place {
+    eprintln!(
+      "Error: --omit-file-header can't be used with --in-place, as the \
+       result would no longer be a valid DICOM P10 file"
+    );
+    return Err(());
+  }
+
   if args.transfer_syntax.is_none() {
     if args.photometric_interpretation_monochrome.is_some() {
       eprintln!(
@@ -487,7 +504,8 @@ async fn modify_input_source(
   // Setup write config
   let write_config = P10WriteConfig::default()
     .implementation_version_name(args.implementation_version_name.clone())
-    .zlib_compression_level(args.zlib_compression_level);
+    .zlib_compression_level(args.zlib_compression_level)
+    .omit_file_header(args.omit_file_header);
 
   let mut input_stream = input_source
     .open_read_stream()

--- a/src/rust/dcmfx_cli/tests/modify.rs
+++ b/src/rust/dcmfx_cli/tests/modify.rs
@@ -236,6 +236,22 @@ fn errors_on_missing_file() {
 }
 
 #[test]
+fn errors_on_omit_file_header_with_in_place() {
+  let assert = dcmfx_cli()
+    .arg("modify")
+    .arg("--omit-file-header")
+    .arg("--in-place")
+    .arg("tmp.dcm")
+    .assert()
+    .failure();
+
+  assert_snapshot!(
+    "errors_on_omit_file_header_with_in_place",
+    get_stderr(assert)
+  );
+}
+
+#[test]
 fn errors_on_photometric_interpretation_monochrome_without_transfer_syntax() {
   let assert = dcmfx_cli()
     .arg("modify")
@@ -396,6 +412,52 @@ fn delete_private_tags() {
     .success();
 
   assert_snapshot!("delete_private_tags_after", get_stdout(assert));
+}
+
+#[test]
+fn modify_omit_file_header() {
+  let temp_dir = create_temp_dir();
+  let input_file = "../../../test/assets/fo-dicom/CT-MONO2-16-ankle.dcm";
+  let full_output_file = temp_dir.path().join("full_output.dcm");
+  let bare_output_file = temp_dir.path().join("bare_output.raw");
+
+  dcmfx_cli()
+    .arg("modify")
+    .arg(input_file)
+    .arg("--output-filename")
+    .arg(&full_output_file)
+    .assert()
+    .success();
+
+  dcmfx_cli()
+    .arg("modify")
+    .arg(input_file)
+    .arg("--output-filename")
+    .arg(&bare_output_file)
+    .arg("--omit-file-header")
+    .assert()
+    .success();
+
+  let full_output = std::fs::read(&full_output_file).unwrap();
+  let bare_output = std::fs::read(&bare_output_file).unwrap();
+
+  // Sanity check that the full output is a normal P10 file, i.e. that our
+  // baseline to compare against is actually meaningful
+  assert_eq!(&full_output[128..132], b"DICM");
+
+  // The File Meta Information Group Length element's value gives the exact
+  // byte length of the rest of the File Meta Information that follows it, so
+  // it precisely determines where the data set starts. This is always at a
+  // fixed offset: 128-byte preamble + 4-byte 'DICM' prefix + 12 bytes for the
+  // group length element itself (4-byte tag + 2-byte VR + 2-byte length +
+  // 4-byte value).
+  let group_length =
+    u32::from_le_bytes(full_output[140..144].try_into().unwrap());
+  let header_length = 144 + group_length as usize;
+
+  // The bare output should be exactly the data set bytes that follow the P10
+  // file header, with nothing added, removed, or altered
+  assert_eq!(bare_output, full_output[header_length..]);
 }
 
 #[test]

--- a/src/rust/dcmfx_cli/tests/snapshots/modify__errors_on_omit_file_header_with_in_place.snap
+++ b/src/rust/dcmfx_cli/tests/snapshots/modify__errors_on_omit_file_header_with_in_place.snap
@@ -1,0 +1,5 @@
+---
+source: dcmfx_cli/tests/modify.rs
+expression: get_stderr(assert)
+---
+Error: --omit-file-header can't be used with --in-place, as the result would no longer be a valid DICOM P10 file

--- a/src/rust/dcmfx_p10/src/p10_write.rs
+++ b/src/rust/dcmfx_p10/src/p10_write.rs
@@ -117,10 +117,21 @@ impl P10WriteContext {
 
         self.transfer_syntax = new_transfer_syntax;
 
-        let token_bytes = self.token_to_bytes(token)?;
-        self.p10_total_byte_count += token_bytes.len() as u64;
-        self.p10_bytes.push(token_bytes);
+        if !self.config.omit_file_header {
+          let token_bytes = self.token_to_bytes(token)?;
+          self.p10_total_byte_count += token_bytes.len() as u64;
+          self.p10_bytes.push(token_bytes);
+        }
 
+        Ok(())
+      }
+
+      // The File Preamble and 'DICM' prefix are omitted from the output when
+      // configured to do so, as they only have meaning as part of the P10
+      // file wrapper around the data set
+      P10Token::FilePreambleAndDICMPrefix { .. }
+        if self.config.omit_file_header =>
+      {
         Ok(())
       }
 

--- a/src/rust/dcmfx_p10/src/p10_write_config.rs
+++ b/src/rust/dcmfx_p10/src/p10_write_config.rs
@@ -10,6 +10,7 @@ pub struct P10WriteConfig {
   pub(crate) implementation_class_uid: String,
   pub(crate) implementation_version_name: String,
   pub(crate) zlib_compression_level: u32,
+  pub(crate) omit_file_header: bool,
 }
 
 impl Default for P10WriteConfig {
@@ -20,6 +21,7 @@ impl Default for P10WriteConfig {
       implementation_version_name: uids::DCMFX_IMPLEMENTATION_VERSION_NAME
         .to_string(),
       zlib_compression_level: 6,
+      omit_file_header: false,
     }
   }
 }
@@ -57,6 +59,22 @@ impl P10WriteConfig {
   ///
   pub fn zlib_compression_level(mut self, value: u32) -> Self {
     self.zlib_compression_level = value.clamp(0, 9);
+    self
+  }
+
+  /// Whether to omit the File Preamble, 'DICM' prefix, and File Meta
+  /// Information from serialized DICOM P10 data, writing only the raw data
+  /// set content that follows them.
+  ///
+  /// The transfer syntax is still read out of the File Meta Information token
+  /// when it's written to the context, as it's needed to correctly serialize
+  /// the data set tokens that follow, but no File Meta Information bytes are
+  /// emitted into the output.
+  ///
+  /// Default: `false`.
+  ///
+  pub fn omit_file_header(mut self, value: bool) -> Self {
+    self.omit_file_header = value;
     self
   }
 }


### PR DESCRIPTION
This adds a `--omit-file-header` option to `modify` that writes just the bytes following the P10 header.